### PR TITLE
Make it possible to add both attributes and children

### DIFF
--- a/lib/resty/tags.lua
+++ b/lib/resty/tags.lua
@@ -204,8 +204,8 @@ function tag:__call(...)
         local v = select(i, ...)
         if type(v) == "table" then
             if getmetatable(v) == tag then
-                c[s+i] = tostring(v)
-            elseif s == 0 and n == 1 and not a then
+                c[#c+1] = tostring(v)
+            elseif not a then
                 local r = {}
                 local i = 1
                 for k, v in pairs(v) do
@@ -225,10 +225,10 @@ function tag:__call(...)
                 end
                 a = concat(r)
             else
-                c[s+i] = (escapers[self.name] or html)(v)
+                c[#c+1] = (escapers[self.name] or html)(v)
             end
         else
-            c[s+i] = (escapers[self.name] or html)(v)
+            c[#c+1] = (escapers[self.name] or html)(v)
         end
     end
     if self.copy then


### PR DESCRIPTION
Hi,

I was testing out the lib and was wondering why I could not add attributes together with children other than strings/text. For example:
```lua
div({id="abc"})                -- working: <div id="abc"></div>
div("abc")                     -- working: <div>abc</div>
div {id="abc"} "def"           -- working: <div id="abc">def</div>
div({id="abc"}, "def")         -- not working: <div>table: 0x1337def</div>
div {id="abc"} div{id="def"}   -- not working, syntax error
div({id="abc"}, div{id="def"}) -- not working, <div>table: 0x1337<>div id="def"></div></div>

```

Either it was broken or not supported by design, see the PR below.

If this behaviour is intended no worries about rejecting!